### PR TITLE
Improve logging and PHP typing

### DIFF
--- a/classes/api/circuit_breaker.php
+++ b/classes/api/circuit_breaker.php
@@ -35,19 +35,19 @@ defined('MOODLE_INTERNAL') || die();
  */
 class circuit_breaker {
     /** @var int The current state of the circuit breaker */
-    private $state;
+    private int $state;
 
     /** @var int The number of consecutive failures */
-    private $failurecount;
+    private int $failurecount;
 
     /** @var int The threshold of failures before opening the circuit */
-    private $failurethreshold;
+    private int $failurethreshold;
 
     /** @var int The time in seconds to wait before attempting to close the circuit again */
-    private $resettimeout;
+    private int $resettimeout;
 
     /** @var int Timestamp of the last failure */
-    private $lastfailuretime;
+    private int $lastfailuretime;
 
     /** @var int State constants: circuit is closed (normal operation) */
     const STATE_CLOSED = 0;

--- a/classes/api/client.php
+++ b/classes/api/client.php
@@ -34,22 +34,22 @@ use local_evento\log\logger;
  */
 class client implements client_interface {
     /** @var \SoapClient The underlying SOAP client */
-    private $soapclient;
+    private \SoapClient $soapclient;
     
     /** @var circuit_breaker The circuit breaker for fault tolerance */
-    private $circuitbreaker;
+    private circuit_breaker $circuitbreaker;
     
     /** @var cache_manager The cache manager */
-    private $cachemanager;
+    private cache_manager $cachemanager;
     
     /** @var logger The logger instance */
-    private $logger;
+    private logger $logger;
     
     /** @var array The retry policy configuration */
-    private $retrypolicy;
+    private array $retrypolicy;
 
     /** @var array The SOAP client options */
-    private $options = [];
+    private array $options = [];
 
     /**
      * Constructor.

--- a/classes/api/filter/array_response_filter.php
+++ b/classes/api/filter/array_response_filter.php
@@ -23,8 +23,8 @@ defined('MOODLE_INTERNAL') || die();
  */
 class array_response_filter implements filter_interface {
     public function apply($response) {
-        // Add debugging to see what comes in and goes out
-        echo "DEBUG Filter input: " . json_encode($response) . "\n";
+        // Log the incoming response for debugging purposes.
+        debugging('Filter input: ' . json_encode($response), DEBUG_DEVELOPER);
         
         // Standard processing
         if (is_object($response) && isset($response->return)) {
@@ -38,7 +38,8 @@ class array_response_filter implements filter_interface {
                 $result = [];
             }
             
-            echo "DEBUG Filter output: " . json_encode($result) . "\n";
+            // Log the filtered output when debugging is enabled.
+            debugging('Filter output: ' . json_encode($result), DEBUG_DEVELOPER);
             return $result;
         }
         

--- a/classes/api/response_processor.php
+++ b/classes/api/response_processor.php
@@ -27,7 +27,8 @@ namespace local_evento\api;
 defined('MOODLE_INTERNAL') || die();
 
 class response_processor {
-    private $filters = [];
+    /** @var array<filter_interface> */
+    private array $filters = [];
     
     public function addFilter($filter) {
         $this->filters[] = $filter;

--- a/classes/cache/cache_manager.php
+++ b/classes/cache/cache_manager.php
@@ -43,7 +43,7 @@ class cache_manager implements cache_manager_interface {
     const TTL_EVENT_MAPPING = 86400;   // 1 day
     const TTL_USER_MAPPING = 86400;    // 1 day
     
-    private $caches = [];
+    private array $caches = [];
     
     public function __construct() {
         // Initialize the cache stores for each region

--- a/classes/data/repository.php
+++ b/classes/data/repository.php
@@ -40,13 +40,13 @@ defined('MOODLE_INTERNAL') || die();
  */
 class repository implements repository_interface {
     /** @var client_interface The API client */
-    private $apiClient;
+    private client_interface $apiClient;
     
     /** @var cache_manager The cache manager */
-    private $cacheManager;
+    private cache_manager $cacheManager;
     
     /** @var response_processor The response processor */
-    private $responseProcessor;
+    private response_processor $responseProcessor;
     
     /**
      * Constructor.

--- a/classes/log/logger.php
+++ b/classes/log/logger.php
@@ -32,10 +32,10 @@ defined('MOODLE_INTERNAL') || die();
  */
 class logger implements logger_interface {
     /** @var \progress_trace The trace instance for real-time output */
-    private $trace;
+    private \progress_trace $trace;
     
     /** @var string The component name for logging */
-    private $component;
+    private string $component;
     
     /** @var array Mapping of log levels to Moodle debug levels */
     const LOG_LEVEL_MAP = [
@@ -165,10 +165,6 @@ class logger implements logger_interface {
             // Use Moodle's debugging function
             debugging($prefixedMessage, $dbgLevel);
             
-            // For error and warning, also write to PHP error log to ensure visibility
-            if ($level === 'error' || $level === 'warning') {
-                error_log($prefixedMessage);
-            }
         }
     }
 

--- a/classes/service.php
+++ b/classes/service.php
@@ -45,25 +45,25 @@ class service {
     const DATETIME_FORMAT = "Y-m-d\TH:i:s.uP";
     
     /** @var repository The repository instance */
-    private $repository;
+    private repository $repository;
     
     /** @var client The API client instance */
-    private $client;
+    private client $client;
     
     /** @var cache_manager The cache manager instance */
-    private $cachemanager;
+    private cache_manager $cachemanager;
     
     /** @var logger The logger instance */
-    private $logger;
+    private logger $logger;
     
     /** @var object The plugin configuration */
-    private $config;
+    private object $config;
     
     /** @var service Singleton instance */
-    private static $instance;
+    private static ?service $instance = null;
 
     /** @var response_processor The response processor */
-    private $responseprocessor;
+    private response_processor $responseprocessor;
 
     /**
      * Constructor.

--- a/composer.json
+++ b/composer.json
@@ -10,12 +10,7 @@
     },
 
     "minimum-stability": "stable",
-    "prefer-stable": true,  
-    "autoload": {
-      "psr-4": {
-        "Fhgr\\MoodleLocalEvento\\": "src/"
-      }
-    },
+    "prefer-stable": true,
   
     "authors": [
       { "name": "Julien Rädler" }

--- a/version.php
+++ b/version.php
@@ -25,7 +25,7 @@
 defined('MOODLE_INTERNAL') || die;
 
 $plugin->version   = 2023112401; // The current module version (Date: YYYYMMDDXX)
-$plugin->requires  = 2016120503; // Requires this Moodle version
+$plugin->requires  = 2023111300; // Requires this Moodle 5.0 version
 $plugin->component = 'local_evento'; // Full name of the plugin (used for diagnostics).
 $plugin->maturity  = MATURITY_STABLE;
 $plugin->release   = "1.2.1"; // User-friendly version number.


### PR DESCRIPTION
## Summary
- drop autoload from composer.json
- make service, client and helper classes use typed properties
- use Moodle `debugging()` for array response filter
- remove `error_log()` calls in logger
- bump plugin requirement for Moodle 5.0